### PR TITLE
Simplify setup

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.7]
 
     steps:
     - uses: actions/checkout@v2
@@ -30,7 +30,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools
         pip install flake8
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install .
     - name: Lint with flake8
       run: |
         flake8 src --count --exit-zero --show-source --statistics

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ source venv/bin/activate
 # Update pip
 pip install -U pip
 
-# Install the DRL package and its requirements
-pip install -r requirements.txt
+# Install the DRL package and its requirements (-e is for dev install)
+pip install -e .
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ pip install -U pip
 pip install -e .
 ```
 
+On Windows 10+, you might need to install MPI separately: https://stackoverflow.com/a/54907810/2745116
+
 ## Usage
 
 The inputs available for the DRL agent are placed in the `inputs` folder. 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
---editable git://github.com/RealVNF/common-utils#egg=common-utils
---editable git://github.com/RealVNF/coord-sim#egg=coord-sim
---editable .

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ requirements = [
     'gym[atari]==0.15.7',
     'mpi4py==3.0.3',
     'tqdm',
-    'networkx==2.4'
+    'networkx==2.4',
+    'protobuf<=3.20.3'
 ]
 
 test_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from setuptools import setup, find_packages
 requirements = [
+    'coord-sim==2.2.1',
     'tensorflow==1.14',
     'click',
     'stable-baselines==2.10',
@@ -18,7 +19,7 @@ test_requirements = [
 
 setup(
     name='spr-rl',
-    version='1.0.1',
+    version='1.0.2',
     description='Distributed Online Service Coordination Using Deep Reinforcement Learning',
     url='https://github.com/RealVNF/distributed-drl-coordination',
     author='Haydar Qarawlus, Stefan Schneider',


### PR DESCRIPTION
Closes #3 

Pin to coord-sim 2.2.1 and install from PyPI directly
Update install instructions and pipeline.